### PR TITLE
Add git alias for message templates

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -49,6 +49,11 @@
       # typing is for losers
       co          = checkout
 
+      # utilizes a message template
+      # usage:
+      #  git done foo.txt
+      done        = !git commit -evF
+
       # outputs verbose information about branch pointers
       br          = !git branch -vv -a
 


### PR DESCRIPTION
Sometimes I want to work on my commit messages as I go. The `done` alias
will allow me to do this without specifying any special options, aside
from the commit message template.

Usage:

git done <file>
